### PR TITLE
protect-wall

### DIFF
--- a/anything.cpp
+++ b/anything.cpp
@@ -1,20 +1,57 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+using namespace std::chrono_literals;
+
+class SelfDrive : public rclcpp::Node
+{
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
+  int step_;
+
+public:
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0)
+  {
+    auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile,
+                                                                       callback);
+    auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
+  }
+
   void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
   {
     geometry_msgs::msg::Twist vel;
-    
-    vel.linear.x = 2.0;
-    vel.angular.z = 0.;
-    
-    if (scan->ranges[0] < 0.3)
+
+    vel.linear.x = 0.2;
+    vel.angular.z = 0.0;
+
+    if (scan->ranges[0] <= 0.25 || scan->ranges[20] <= 0.25)
     {
       vel.linear.x = 0.;
-      vel.angular.z = 0.;
+      vel.angular.z = -1.5;
     }
-    else
+   
+    else if(scan->ranges[60] <= 0.25)
     {
-      vel.linear.x = 0.1;
-      vel.angular.z = 0.;
+      vel.linear.x = 0.15;
+      vel.angular.z = -0.0001;
     }
+    else if(scan->ranges[90] <= 0.20)
+    {
+      vel.linear.x = 0.;
+      vel.angular.z = 1.5;
+    }
+   
     RCLCPP_INFO(rclcpp::get_logger("self_drive"),
                 "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f", step_, scan->ranges[0],
                 vel.linear.x, vel.angular.z);
@@ -22,3 +59,12 @@
     step_++;
   }
 };
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<SelfDrive>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/anything.cpp
+++ b/anything.cpp
@@ -46,7 +46,7 @@ public:
       vel.linear.x = 0.15;
       vel.angular.z = -0.0001;
     }
-    else if(scan->ranges[90] <= 0.20)
+    else if(scan->ranges[90] <= 0.20 && !(scan->ranges[60] <= 0.25))
     {
       vel.linear.x = 0.;
       vel.angular.z = 1.5;


### PR DESCRIPTION
main에 올라온 코드는 정면에서 장애물을 만나면 정지하는 코드이고 이번 코드는 장애물을 만났을 때 좌회전 하여 벽을 따라가는 코드로 만들어 봤습니다.
정면에서 장애물을 만났을 시 우회전을 하는 코드는 팀원인 장시영학생의 코드를 활용했습니다.

-레이더가 0도나 20도 사이에 장애물을 감지하면 우회전을 하는 코드를 먼저 구현 후 직진과 좌회전을 하는 코드를 구성했습니다.
-벽을 감지하면 직진을 하기 위해 레이더의 60도에 벽이 감지되면 앞으로 직진. 단 벽에 너무 붙지 않도록 아주 미세하게 좌회전을 하면서 진행했습니다.
-60에서 레이더가 감지하지 못할 시 90도 레이더 사용, 90도에 벽이 감지되면 왼쪽에 벽이 없다고 판단하고 좌회전을 실시
-그러다 다시 60도 감지되면 다시 벽을 따라가도록 했습니다.